### PR TITLE
Update modHideSearchInput.js to reduce the time interval between overview showing and search bar hiding

### DIFF
--- a/src/modHideSearchInput.js
+++ b/src/modHideSearchInput.js
@@ -11,7 +11,7 @@ var Mod = class extends mod.Base {
         //  Dash2Dock would have time to initialize. We need this hack only once, so it disconnects from that signal
         //  right away.
         const onceConnectId = Main.overview.connect('showing', () => {
-            this.enableTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+            this.enableTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
                 Main.overview.searchEntry.hide()
                 delete this.enableTimeoutId
                 return GLib.SOURCE_REMOVE


### PR DESCRIPTION
It probably solved issue#34. Its stuttering is now less noticeable and more quicker. Maybe others can try implementing a way to know whether Dash2Dock is installed or not to let the wait be 0ms or 50ms depending. I don't know how to do that.