### PR TITLE
Gnome 48 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "url": "https://github.com/axxapy/gnome-ui-tune",
   "uuid": "gnome-ui-tune@itstime.tech",
   "settings-schema": "org.gnome.shell.extensions.gnome-ui-tune",
-  "shell-version": ["45", "46", "47"]
+  "shell-version": ["45", "46", "47", "48"]
 }


### PR DESCRIPTION
Everything works as it did before without any code changes.

The only thing I didn't test fully is showing Firefox PIP window in overview, as I never used the setting & it seems to always show in overview, no matter if it's off or on.