### PR TITLE
Issue 50 - Add support for Gnome 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "url": "https://github.com/axxapy/gnome-ui-tune",
   "uuid": "gnome-ui-tune@itstime.tech",
   "settings-schema": "org.gnome.shell.extensions.gnome-ui-tune",
-  "shell-version": ["45", "46", "47", "48", "49"]
+  "shell-version": ["45", "46", "47", "48", "49", "50"]
 }

--- a/src/modRestoreThumbnailsBackground.js
+++ b/src/modRestoreThumbnailsBackground.js
@@ -15,6 +15,17 @@ export default class extends Mod {
                 container: this._contents,
                 vignette: false
             });
+
+            // Shell 50: when the wallpaper image finishes loading after the
+            // thumbnail is built (cold cache on cold boot, or after resume
+            // invalidates the cache), the Meta.BackgroundActor's preferred
+            // size update no longer always propagates to its parent's
+            // allocation, leaving the thumbnail blank until something else
+            // (e.g. switching workspaces) forces a relayout. Force one
+            // ourselves on every load and on every actor swap.
+            const requeue = () => this._bgManager.backgroundActor?.queue_relayout()
+            this._bgManagerLoadedId  = this._bgManager.connect('loaded',  requeue)
+            this._bgManagerChangedId = this._bgManager.connect('changed', requeue)
         }
 
         this.bkp_thumb_onDestroy = WorkspaceThumbnail.prototype._onDestroy;
@@ -22,6 +33,14 @@ export default class extends Mod {
         WorkspaceThumbnail.prototype._onDestroy = function() {
             _onDestroy.call(this)
             if (this._bgManager) {
+                if (this._bgManagerLoadedId) {
+                    this._bgManager.disconnect(this._bgManagerLoadedId)
+                    this._bgManagerLoadedId = 0
+                }
+                if (this._bgManagerChangedId) {
+                    this._bgManager.disconnect(this._bgManagerChangedId)
+                    this._bgManagerChangedId = 0
+                }
                 this._bgManager.destroy();
                 this._bgManager = null;
             }


### PR DESCRIPTION
Add support for Gnome 50

Update the metadata.json file and also deal with background redraw issue as reported in issue #50.

This is working well on my own system running Fedora 44 which ships with Gnome 50.
